### PR TITLE
Fix an error associated with importing conftest.py.

### DIFF
--- a/tests/test_fluid.py
+++ b/tests/test_fluid.py
@@ -1,4 +1,4 @@
-from conftest import run_with_reference
+from .conftest import run_with_reference
 
 # Common folder for all tests in this file
 base_folder = "fluid"


### PR DESCRIPTION
I forgot to change "from conftest import run_with_reference" back to "from .conftest import run_with_reference" when I made the previous commit.
